### PR TITLE
Add support and tests for mindate/maxdate params for plays

### DIFF
--- a/boardgamegeek/api.py
+++ b/boardgamegeek/api.py
@@ -328,12 +328,16 @@ class BoardGameGeekNetworkAPI(object):
 
         return user
 
-    def plays(self, name=None, game_id=None, progress=None):
+    def plays(self, name=None, game_id=None, progress=None, mindate=None, maxdate=None):
         """
         Retrieves the user's play list
 
         :param name: user name to retrieve the plays for
         :param game_id: game id to retrieve the plays for
+        :param mindate: return only plays of the specified date or later.
+        :param maxdate: return only plays of the specified date or earlier.
+        :type mindate: datetime.date
+        :type maxdate: datetime.date
         :return: :py:class:`boardgamegeek.plays.Plays` object containing all the plays
         :raises: :py:class:`boardgamegeek.exceptions.BoardGameGeekError` on errors
         :raises: :py:class:`boardgamegeek.exceptions.BoardGameGeekAPIRetryError` if this request should be retried after a short delay
@@ -354,6 +358,18 @@ class BoardGameGeekNetworkAPI(object):
                 params = {"id": int(game_id)}
             except:
                 raise BoardGameGeekError("invalid game id")
+
+        if mindate:
+            try:
+                params["mindate"] = mindate.isoformat()
+            except AttributeError:
+                raise BoardGameGeekError("mindate must be a datetime.date object")
+
+        if maxdate:
+            try:
+                params["maxdate"] = maxdate.isoformat()
+            except AttributeError:
+                raise BoardGameGeekError("maxdate must be a datetime.date object")
 
         try:
             root = get_parsed_xml_response(self.requests_session,

--- a/test/test_bgg.py
+++ b/test/test_bgg.py
@@ -439,6 +439,26 @@ def test_get_plays_with_unknown_username_and_id(bgg):
     assert len(plays) == 0
 
 
+def test_get_plays_with_invalid_dates(bgg):
+    time.sleep(10)
+
+    # A string is invalid so should raise an error
+    with pytest.raises(BoardGameGeekError):
+        bgg.plays(name=TEST_VALID_USER, mindate="2014-01-01")
+
+    with pytest.raises(BoardGameGeekError):
+        bgg.plays(name=TEST_VALID_USER, maxdate="2014-12-31")
+
+
+def test_get_plays_with_valid_dates(bgg):
+    time.sleep(10)
+
+    mindate = datetime.date(2014, 1, 1)
+    maxdate = datetime.date(2014, 12, 31)
+    plays = bgg.plays(TEST_VALID_USER, mindate=mindate, maxdate=maxdate)
+    assert len(plays) > 0
+
+
 def test_get_plays_of_user(bgg, null_logger):
     time.sleep(10)
 


### PR DESCRIPTION
This pull request adds basic support for mindate/maxdate params on plays.
It accepts only datetime.date objects (not strings, etc.) and throws the BoardGameGeekError if it fails to convert.

The test for valid dates is potentially a bit dodgy if the TEST_VALID_USER changes, so there might be a better way!