### PR TITLE
Fix issue with infinite recursion on the DictObject used for resources.

### DIFF
--- a/boardgamegeek/utils.py
+++ b/boardgamegeek/utils.py
@@ -41,7 +41,7 @@ class DictObject(object):
 
     def __getattr__(self, item):
         # allow accessing user's variables using .attribute
-        if item in self._data:
+        if item != "_data" and item in self._data:
             return self._data[item]
         raise AttributeError
 


### PR DESCRIPTION
Came across this bug when trying to unpickle API objects - the fix prevents getattr from trying to infinitely access the _data attribute.

Should probably write a test for this but not sure how best to do it, any suggestions?