### PR TITLE
Support board game accessories

### DIFF
--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -11,7 +11,7 @@ log = logging.getLogger("boardgamegeek.loaders.game")
 def create_game_from_xml(xml_root, game_id, html_parser):
 
     game_type = xml_root.attrib["type"]
-    if game_type not in ["boardgame", "boardgameexpansion"]:
+    if game_type not in ["boardgame", "boardgameexpansion", "boardgameaccessory"]:
         log.debug("unsupported type {} for item id {}".format(game_type, game_id))
         raise BGGApiError("item has an unsupported type")
 
@@ -21,6 +21,7 @@ def create_game_from_xml(xml_root, game_id, html_parser):
             "thumbnail": xml_subelement_text(xml_root, "thumbnail"),
             "image": xml_subelement_text(xml_root, "image"),
             "expansion": game_type == "boardgameexpansion",       # is this game an expansion?
+            "accessory": game_type == "boardgameaccessory",       # is this game an accessory?
             "families": xml_subelement_attr_list(xml_root, "link[@type='boardgamefamily']"),
             "categories": xml_subelement_attr_list(xml_root, "link[@type='boardgamecategory']"),
             "implementations": xml_subelement_attr_list(xml_root, "link[@type='boardgameimplementation']"),

--- a/boardgamegeek/objects/games.py
+++ b/boardgamegeek/objects/games.py
@@ -762,7 +762,7 @@ class BoardGame(BaseGame):
             self.add_comment(comment)
 
         self._player_suggestion = []
-        if "suggested_players" in data:
+        if "suggested_players" in data and "results" in data['suggested_players']:
             for count, result in data['suggested_players']['results'].items():
                 suggestion_data = {
                     'player_count': count,
@@ -826,6 +826,7 @@ class BoardGame(BaseGame):
         log.info("image             : {}".format(self.image))
 
         log.info("is expansion      : {}".format(self.expansion))
+        log.info("is accessory      : {}".format(self.accessory))
 
         if self.expansions:
             log.info("expansions")
@@ -1005,6 +1006,14 @@ class BoardGame(BaseGame):
         :rtype: bool
         """
         return self._data.get("expansion", False)
+
+    @property
+    def accessory(self):
+        """
+        :return: True if this item is an accessory
+        :rtype: bool
+        """
+        return self._data.get("accessory", False)
 
     @property
     def min_age(self):

--- a/test/_common.py
+++ b/test/_common.py
@@ -25,6 +25,8 @@ TEST_GAME_ID_2 = 283
 TEST_GUILD_ID = 1229
 TEST_GUILD_ID_2 = 930
 
+TEST_GAME_ACCESSORY_ID = 104163 # Descent: Journeys in the Dark (second edition) – Conversion Kit
+
 
 @pytest.fixture
 def xml():

--- a/test/_common.py
+++ b/test/_common.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import logging
 import pytest
 import xml.etree.ElementTree as ET

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -204,3 +204,4 @@ def test_get_accessory(bgg):
     game = bgg.game(game_id=TEST_GAME_ACCESSORY_ID)
 
     assert game.id == TEST_GAME_ACCESSORY_ID
+    assert game.accessory

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -199,3 +199,8 @@ def test_get_games_by_name(bgg, null_logger):
         g._format(null_logger)
 
     assert len(games) > 1
+
+def test_get_accessory(bgg):
+    game = bgg.game(game_id=TEST_GAME_ACCESSORY_ID)
+
+    assert game.id == TEST_GAME_ACCESSORY_ID

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -43,8 +43,9 @@ def check_game(game):
     assert game.name == TEST_GAME_NAME
     assert game.id == TEST_GAME_ID
     assert game.year == 2007
-    assert game.mechanics == ['Card Drafting', 'Hand Management',
-                              'Variable Player Powers', 'Worker Placement']
+    assert game.mechanics == ['Area Enclosure', 'Card Drafting',
+                              'Hand Management', 'Variable Player Powers',
+                              'Worker Placement']
     assert game.min_players == 1
     assert game.max_players == 5
     assert game.thumbnail == "https://cf.geekdo-images.com/images/pic259085_t.jpg"


### PR DESCRIPTION
As well as board games and expansions, there are a few board game accessories listed on BoardGameGeek, for instance [Descent: Journeys in the Dark (second edition) – Conversion Kit](https://boardgamegeek.com/boardgameaccessory/104163/descent-journeys-dark-second-edition-conversion-ki). Attempting to fetch one of these currently results in an error due to the unrecognised item.
This PR does the minimum necessary to enable those accessories to be fetched:
- Add the item type "boardgameaccessory" to the list of supported types
- Add an "accessory" property to enable them to be filtered etc

(The PR will get slightly smaller if #33 is merged first)