### PR TITLE
Fix bugs in getting rating_comments and multiple pages of comments

### DIFF
--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -154,7 +154,6 @@ def add_game_comments_from_xml(game, xml_root):
     added_items = False
     total_comments = 0
 
-    # TODO: this is not working (API PROBLEM??)
     comments = xml_root.find("comments")
     if comments is not None:
         total_comments = int(comments.attrib["totalitems"])


### PR DESCRIPTION
First: Thank you very much for developing this library!

I was trying to get all of the ratings for a game, and ran into a few bugs. I have fixed them here.

The changed code should probably be refactored to remove duplication (I copied and pasted a few lines) - extracting a function that is shared between the code that gets the initial game data and the code that gets additional comments. But I decided to open the PR as is because I thought it would be easier to review this way. I'd be happy to do a follow-up commit that extracts this shared function if you'd like.

I have just done a bit of manual testing. Probably some more testing is warranted, but I wasn't sure what to do. I tested with:

```python
g = bgg.game("Forbidden Sky", rating_comments=True)
```

and examining `g.comments`, both with `len(g.comments)` and brief visual examination using:

```python
for c in g.comments:
    print("{}: <{}> <{}>".format(c.username, c.comment, c.rating))
```

See inline comments for details.