### PR TITLE
Bug/50 unescape is deprecated

### DIFF
--- a/boardgamegeek/api.py
+++ b/boardgamegeek/api.py
@@ -19,14 +19,6 @@ import logging
 import sys
 import warnings
 
-# This is required for decoding HTML entities from the description text
-# of games
-if sys.version_info >= (3,):
-    import html.parser as hp
-else:
-    import HTMLParser as hp
-
-
 from .objects.user import User
 from .objects.search import SearchResult
 
@@ -43,7 +35,6 @@ from .loaders import create_game_from_xml, add_game_comments_from_xml
 
 
 log = logging.getLogger("boardgamegeek.api")
-html_parser = hp.HTMLParser()
 
 HOT_ITEM_CHOICES = ["boardgame", "rpg", "videogame", "boardgameperson", "rpgperson", "boardgamecompany",
                     "rpgcompany", "videogamecompany"]
@@ -199,7 +190,7 @@ class BGGCommon(object):
                                          retries=self._retries,
                                          retry_delay=self._retry_delay)
 
-        guild = create_guild_from_xml(xml_root, html_parser)
+        guild = create_guild_from_xml(xml_root)
 
         if not members:
             return guild
@@ -803,8 +794,7 @@ class BGGClient(BGGCommon):
         game_list = []
         for i, game_root in enumerate(xml_root):
             game = create_game_from_xml(game_root,
-                                        game_id=game_id_list[i],
-                                        html_parser=html_parser)
+                                        game_id=game_id_list[i])
             game_list.append(game)
 
         return game_list
@@ -869,8 +859,7 @@ class BGGClient(BGGCommon):
             raise BGGApiError(msg)
 
         game = create_game_from_xml(xml_root,
-                                    game_id=game_id,
-                                    html_parser=html_parser)
+                                    game_id=game_id)
 
         if not (comments or rating_comments):
             return game

--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -1,3 +1,4 @@
+import html
 import logging
 
 from ..objects.games import BoardGame
@@ -29,7 +30,7 @@ def create_game_from_xml(xml_root, game_id, html_parser):
             "designers": xml_subelement_attr_list(xml_root, "link[@type='boardgamedesigner']"),
             "artists": xml_subelement_attr_list(xml_root, "link[@type='boardgameartist']"),
             "publishers": xml_subelement_attr_list(xml_root, "link[@type='boardgamepublisher']"),
-            "description": xml_subelement_text(xml_root, "description", convert=html_parser.unescape, quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html.unescape, quiet=True)}
 
     expands = []        # list of items this game expands
     expansions = []     # list of expansions this game has

--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -1,10 +1,8 @@
-import html
 import logging
 
 from ..objects.games import BoardGame
 from ..exceptions import BGGApiError
-from ..utils import xml_subelement_attr_list, xml_subelement_text, xml_subelement_attr, get_board_game_version_from_element
-
+from ..utils import xml_subelement_attr_list, xml_subelement_text, xml_subelement_attr, get_board_game_version_from_element, html_unescape_function
 
 log = logging.getLogger("boardgamegeek.loaders.game")
 
@@ -30,7 +28,7 @@ def create_game_from_xml(xml_root, game_id, html_parser):
             "designers": xml_subelement_attr_list(xml_root, "link[@type='boardgamedesigner']"),
             "artists": xml_subelement_attr_list(xml_root, "link[@type='boardgameartist']"),
             "publishers": xml_subelement_attr_list(xml_root, "link[@type='boardgamepublisher']"),
-            "description": xml_subelement_text(xml_root, "description", convert=html.unescape, quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html_unescape_function(html_parser), quiet=True)}
 
     expands = []        # list of items this game expands
     expansions = []     # list of expansions this game has

--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -2,7 +2,7 @@ import logging
 
 from ..objects.games import BoardGame
 from ..exceptions import BGGApiError
-from ..utils import xml_subelement_attr_list, xml_subelement_text, xml_subelement_attr, get_board_game_version_from_element, html_unescape_function
+from ..utils import xml_subelement_attr_list, xml_subelement_text, xml_subelement_attr, get_board_game_version_from_element, html_unescape
 
 log = logging.getLogger("boardgamegeek.loaders.game")
 
@@ -28,7 +28,7 @@ def create_game_from_xml(xml_root, game_id, html_parser):
             "designers": xml_subelement_attr_list(xml_root, "link[@type='boardgamedesigner']"),
             "artists": xml_subelement_attr_list(xml_root, "link[@type='boardgameartist']"),
             "publishers": xml_subelement_attr_list(xml_root, "link[@type='boardgamepublisher']"),
-            "description": xml_subelement_text(xml_root, "description", convert=html_unescape_function(html_parser), quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html_unescape, quiet=True)}
 
     expands = []        # list of items this game expands
     expansions = []     # list of expansions this game has

--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -7,7 +7,7 @@ from ..utils import xml_subelement_attr_list, xml_subelement_text, xml_subelemen
 log = logging.getLogger("boardgamegeek.loaders.game")
 
 
-def create_game_from_xml(xml_root, game_id, html_parser):
+def create_game_from_xml(xml_root, game_id):
 
     game_type = xml_root.attrib["type"]
     if game_type not in ["boardgame", "boardgameexpansion", "boardgameaccessory"]:

--- a/boardgamegeek/loaders/guild.py
+++ b/boardgamegeek/loaders/guild.py
@@ -1,10 +1,16 @@
-import html
 import logging
 
 from ..objects.guild import Guild
 from ..exceptions import BGGItemNotFoundError
-from ..utils import xml_subelement_text
+from ..utils import xml_subelement_text, html_unescape_function
 
+unescape_fn_factory = lambda hp: hp.unescape
+try:
+    import html
+    if hasattr(html, 'unescape'):
+        unescape_fn_factory = lambda hp: html.unescape
+except ImportError:
+    pass # Expected in Python 2
 
 log = logging.getLogger("boardgamegeek.loaders.guild")
 
@@ -21,7 +27,7 @@ def create_guild_from_xml(xml_root, html_parser):
             "category": xml_subelement_text(xml_root, "category"),
             "website": xml_subelement_text(xml_root, "website"),
             "manager": xml_subelement_text(xml_root, "manager"),
-            "description": xml_subelement_text(xml_root, "description", convert=html.unescape, quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html_unescape_function(html_parser), quiet=True)}
 
     # Grab location info
     location = xml_root.find("location")

--- a/boardgamegeek/loaders/guild.py
+++ b/boardgamegeek/loaders/guild.py
@@ -4,13 +4,6 @@ from ..objects.guild import Guild
 from ..exceptions import BGGItemNotFoundError
 from ..utils import xml_subelement_text, html_unescape_function
 
-unescape_fn_factory = lambda hp: hp.unescape
-try:
-    import html
-    if hasattr(html, 'unescape'):
-        unescape_fn_factory = lambda hp: html.unescape
-except ImportError:
-    pass # Expected in Python 2
 
 log = logging.getLogger("boardgamegeek.loaders.guild")
 

--- a/boardgamegeek/loaders/guild.py
+++ b/boardgamegeek/loaders/guild.py
@@ -2,7 +2,7 @@ import logging
 
 from ..objects.guild import Guild
 from ..exceptions import BGGItemNotFoundError
-from ..utils import xml_subelement_text, html_unescape_function
+from ..utils import xml_subelement_text, html_unescape
 
 
 log = logging.getLogger("boardgamegeek.loaders.guild")
@@ -20,7 +20,7 @@ def create_guild_from_xml(xml_root, html_parser):
             "category": xml_subelement_text(xml_root, "category"),
             "website": xml_subelement_text(xml_root, "website"),
             "manager": xml_subelement_text(xml_root, "manager"),
-            "description": xml_subelement_text(xml_root, "description", convert=html_unescape_function(html_parser), quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html_unescape, quiet=True)}
 
     # Grab location info
     location = xml_root.find("location")

--- a/boardgamegeek/loaders/guild.py
+++ b/boardgamegeek/loaders/guild.py
@@ -1,3 +1,4 @@
+import html
 import logging
 
 from ..objects.guild import Guild
@@ -20,7 +21,7 @@ def create_guild_from_xml(xml_root, html_parser):
             "category": xml_subelement_text(xml_root, "category"),
             "website": xml_subelement_text(xml_root, "website"),
             "manager": xml_subelement_text(xml_root, "manager"),
-            "description": xml_subelement_text(xml_root, "description", convert=html_parser.unescape, quiet=True)}
+            "description": xml_subelement_text(xml_root, "description", convert=html.unescape, quiet=True)}
 
     # Grab location info
     location = xml_root.find("location")

--- a/boardgamegeek/loaders/guild.py
+++ b/boardgamegeek/loaders/guild.py
@@ -8,7 +8,7 @@ from ..utils import xml_subelement_text, html_unescape
 log = logging.getLogger("boardgamegeek.loaders.guild")
 
 
-def create_guild_from_xml(xml_root, html_parser):
+def create_guild_from_xml(xml_root):
 
     if "name" not in xml_root.attrib:
         raise BGGItemNotFoundError("name not found")

--- a/boardgamegeek/utils.py
+++ b/boardgamegeek/utils.py
@@ -20,6 +20,7 @@ import time
 import threading
 from requests.adapters import HTTPAdapter
 
+
 try:
     import urllib.parse as urlparse
 except:
@@ -423,7 +424,7 @@ def html_unescape_function(html_parser):
     :param html_parser: an HTML parser (HTMLParser in Python 2, html.parser in Python 3)
     :return: a function which will unescape HTML
     """
-    if 'html' in sys.modules and hasattr(html, 'unescape'):
+    if "html" in sys.modules and hasattr(html, "unescape"):
         return html.unescape # The module level function
     else:
         return html_parser.unescape # The object level function

--- a/boardgamegeek/utils.py
+++ b/boardgamegeek/utils.py
@@ -20,11 +20,15 @@ import time
 import threading
 from requests.adapters import HTTPAdapter
 
-
 try:
     import urllib.parse as urlparse
 except:
     import urlparse
+
+try:
+    import html
+except ImportError:
+    pass # Expected to fail on Python 2
 
 from .exceptions import BGGApiError, BGGApiRetryError, BGGError, BGGApiTimeoutError
 
@@ -409,3 +413,17 @@ def get_board_game_version_from_element(xml_elem):
         data[item] = xml_subelement_attr(xml_elem, item, convert=float, quiet=True, default=0.0)
 
     return data
+
+def html_unescape_function(html_parser):
+    """
+    Given an HTML parser object, return a function which can be used to unescape HTML.
+
+    A compatibility shim to deal with the unescape function moving around.
+
+    :param html_parser: an HTML parser (HTMLParser in Python 2, html.parser in Python 3)
+    :return: a function which will unescape HTML
+    """
+    if 'html' in sys.modules and hasattr(html, 'unescape'):
+        return html.unescape # The module level function
+    else:
+        return html_parser.unescape # The object level function

--- a/boardgamegeek/utils.py
+++ b/boardgamegeek/utils.py
@@ -26,10 +26,16 @@ try:
 except:
     import urlparse
 
+# Compatibility shim which gives us a working "unescape HTML" function on all Python versions
 try:
     import html
-except ImportError:
-    pass # Expected to fail on Python 2
+    html_unescape = html.unescape # Python 3.4+
+except AttributeError: # Python 3.0 - 3.3
+    import html.parser
+    html_unescape = html.parser.HTMLParser().unescape
+except ImportError: # Python 2
+    import HTMLParser
+    html_unescape = HTMLParser.HTMLParser().unescape
 
 from .exceptions import BGGApiError, BGGApiRetryError, BGGError, BGGApiTimeoutError
 
@@ -414,17 +420,3 @@ def get_board_game_version_from_element(xml_elem):
         data[item] = xml_subelement_attr(xml_elem, item, convert=float, quiet=True, default=0.0)
 
     return data
-
-def html_unescape_function(html_parser):
-    """
-    Given an HTML parser object, return a function which can be used to unescape HTML.
-
-    A compatibility shim to deal with the unescape function moving around.
-
-    :param html_parser: an HTML parser (HTMLParser in Python 2, html.parser in Python 3)
-    :return: a function which will unescape HTML
-    """
-    if "html" in sys.modules and hasattr(html, "unescape"):
-        return html.unescape # The module level function
-    else:
-        return html_parser.unescape # The object level function

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,11 +7,6 @@ import boardgamegeek.utils as bggutil
 from _common import *
 from boardgamegeek.objects.things import Thing
 
-if sys.version_info >= (3,):
-    import html.parser as hp
-else:
-    import HTMLParser as hp
-
 def test_get_xml_subelement_attr(xml):
 
     node = bggutil.xml_subelement_attr(None, "hello")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -176,9 +176,7 @@ def test_rate_limiting_for_requests():
 
 def test_html_unescape_function():
     escaped = "&lt;tag&gt;"
-    html_parser = hp.HTMLParser()
 
-    unescape_fn = bggutil.html_unescape_function(html_parser)
-    unescaped = unescape_fn(escaped)
+    unescaped = bggutil.html_unescape(escaped)
 
     assert unescaped == "<tag>"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,6 +7,10 @@ import boardgamegeek.utils as bggutil
 from _common import *
 from boardgamegeek.objects.things import Thing
 
+if sys.version_info >= (3,):
+    import html.parser as hp
+else:
+    import HTMLParser as hp
 
 def test_get_xml_subelement_attr(xml):
 
@@ -169,3 +173,12 @@ def test_rate_limiting_for_requests():
         bgg.game(game_id=g)
 
     assert 0 < time.time() - end_time < 2
+
+def test_html_unescape_function():
+    escaped = "&lt;tag&gt;"
+    html_parser = hp.HTMLParser()
+
+    unescape_fn = bggutil.html_unescape_function(html_parser)
+    unescaped = unescape_fn(escaped)
+
+    assert unescaped == "<tag>"


### PR DESCRIPTION
Adds a compatibility shim which ends up using:

- `HTMLParser.unescape()` on Python 2.x
- `html_parser.unescape()` on Python 3.0 to 3.3
- `html.unescape()` on Python 3.4+