### PR TITLE
set game data id to BGG id instead of search id

### DIFF
--- a/boardgamegeek/loaders/game.py
+++ b/boardgamegeek/loaders/game.py
@@ -13,8 +13,8 @@ def create_game_from_xml(xml_root, game_id):
     if game_type not in ["boardgame", "boardgameexpansion", "boardgameaccessory"]:
         log.debug("unsupported type {} for item id {}".format(game_type, game_id))
         raise BGGApiError("item has an unsupported type")
-
-    data = {"id": game_id,
+    bgg_game_id = int(xml_root.attrib["id"])
+    data = {"id": bgg_game_id,
             "name": xml_subelement_attr(xml_root, "name[@type='primary']"),
             "alternative_names": xml_subelement_attr_list(xml_root, "name[@type='alternate']"),
             "thumbnail": xml_subelement_text(xml_root, "thumbnail"),


### PR DESCRIPTION
When performing a game_list (Thing) search using an id parameter, the requested id doesn't match the response id that comes from the BGG's XMLAPI2.

Way to reproduce: perform a game_list search using id = 1 as a parameter, the response item has an id of 2.

Found the id mismatch while coding a program to get the game expansions from a game after having got the whole data. The expansion ids didn't match the correct items.